### PR TITLE
Clean the code to remove if statement

### DIFF
--- a/src/main/java/stobberi/components/TaskList.java
+++ b/src/main/java/stobberi/components/TaskList.java
@@ -121,16 +121,12 @@ public class TaskList {
         int n = 1;
         for (int i = 1; i < listOfTasks.size() + 1; i++) {
             Task task = listOfTasks.get(i - 1);
-            if (task instanceof Deadline deadline) {
-                if (deadline.isDuring(date)) {
-                    list += n + ". " + listOfTasks.get(i - 1) + "\n";
-                    n++;
-                }
-            } else if (task instanceof Event event) {
-                if (event.isDuring(date)) {
-                    list += n + ". " + listOfTasks.get(i - 1) + "\n";
-                    n++;
-                }
+            if (task instanceof Deadline deadline && deadline.isDuring(date)) {
+                list += n + ". " + listOfTasks.get(i - 1) + "\n";
+                n++;
+            } else if (task instanceof Event event && event.isDuring(date)) {
+                list += n + ". " + listOfTasks.get(i - 1) + "\n";
+                n++;
             }
         }
         return list;


### PR DESCRIPTION
TaskList has a function filterListByDate() which has an if statement that checks if the event is during the date. However, this is not necessary.

Let's remove this if statement.

By removing this if statement, we are able to shorten the length of our method and also avoid deep nesting.